### PR TITLE
Add compute shader support with ".comp" extension.

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 
 const extensions = {
+    comp: 'compute',
     frag: 'fragment',
     vert: 'vertex'
 };


### PR DESCRIPTION
This adds support for compute shaders.

With this PR the plugin will support all shader types that `@webgpu/glslang` supports.